### PR TITLE
Nissix plugin scope-packages on titanium-mobile-web

### DIFF
--- a/mobileweb/package.json
+++ b/mobileweb/package.json
@@ -1,24 +1,24 @@
 {
-	"name": "titanium-mobile-web",
-	"title": "Mobile Web",
-	"description": "Appcelerator Titanium Mobile Web",
-	"keywords": [
-		"appcelerator",
-		"titanium",
-		"mobile",
-		"html5",
-		"mobileweb",
-		"mobile web"
-	],
-	"version": "__VERSION__",
-	"author": "Appcelerator, Inc. <info@appcelerator.com>",
-	"maintainers": [
-		"Chris Barber <cbarber@appcelerator.com>",
-		"Bryan Hughes <bhughes@appcelerator.com>"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/appcelerator/titanium_mobile_web.git"
-	},
-	"license": "Apache Public License v2"
+  "name": "titanium-mobile-web",
+  "title": "Mobile Web",
+  "description": "Appcelerator Titanium Mobile Web",
+  "keywords": [
+    "appcelerator",
+    "titanium",
+    "mobile",
+    "html5",
+    "mobileweb",
+    "mobile web"
+  ],
+  "version": "__VERSION__",
+  "author": "Appcelerator, Inc. <info@appcelerator.com>",
+  "maintainers": [
+    "Chris Barber <cbarber@appcelerator.com>",
+    "Bryan Hughes <bhughes@appcelerator.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/appcelerator/titanium_mobile_web.git"
+  },
+  "license": "Apache Public License v2"
 }

--- a/mobileweb/titanium/package.json
+++ b/mobileweb/titanium/package.json
@@ -1,29 +1,34 @@
 {
-	"name": "Ti",
-	"description": "The Titanium Mobile Web AMD package",
-	"version": "__VERSION__",
-	"keywords": ["Titanium", "Ti", "mobile", "JavaScript"],
-	"licenses": [
-		 {
-			 "type": "Apache License v2",
-			 "url": "https://github.com/appcelerator/titanium_mobile/blob/master/LICENSE"
-		 }
-	],
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/appcelerator/titanium_mobile.git",
-			"path": "packages/Ti"
-		}
-	],
-	"homepage": "https://github.com/appcelerator/titanium_mobile",
-	"directories": {
-		"lib": "."
-	},
-	"main": "./Ti",
-	"titanium": {
-		"timestamp": "__TIMESTAMP__",
-		"githash": "__GITHASH__",
-		"version": "__VERSION__"
-	}
+  "name": "Ti",
+  "description": "The Titanium Mobile Web AMD package",
+  "version": "__VERSION__",
+  "keywords": [
+    "Titanium",
+    "Ti",
+    "mobile",
+    "JavaScript"
+  ],
+  "licenses": [
+    {
+      "type": "Apache License v2",
+      "url": "https://github.com/appcelerator/titanium_mobile/blob/master/LICENSE"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/appcelerator/titanium_mobile.git",
+      "path": "packages/Ti"
+    }
+  ],
+  "homepage": "https://github.com/appcelerator/titanium_mobile",
+  "directories": {
+    "lib": "."
+  },
+  "main": "./Ti",
+  "titanium": {
+    "timestamp": "__TIMESTAMP__",
+    "githash": "__GITHASH__",
+    "version": "__VERSION__"
+  }
 }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.708s



Output Log:
Migrating package "titanium-mobile-web" in mobileweb


## Migration from non scope to @wix/scoped packages
> /tmp/b259f2a2ab35056844826c31a3bf8c3c/mobileweb

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
titanium/package.json
```

